### PR TITLE
feat(tests): better test tools and examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -1503,6 +1504,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
-        "@testing-library/jest-dom": "^6.4.8",
+        "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -1377,14 +1377,13 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.8.tgz",
-      "integrity": "sha512-JD0G+Zc38f5MBHA4NgxQMR5XtO5Jx9g86jqturNTt2WUfRmLDIY7iKkWHDCCTiDuFMre6nxAD5wHw9W5kI4rGw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.5.0.tgz",
+      "integrity": "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
-        "@babel/runtime": "^7.9.2",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
         "css.escape": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^6.4.8",
+    "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/setup-tests.ts
+++ b/setup-tests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -12,6 +12,7 @@ afterEach(cleanup)
 test('renders app component', () => {
   render(<App />)
 
+  expect(screen.getByTestId('title')).toBeInTheDocument()
   expect(screen.getByTestId('title').textContent).toEqual('Hello there 👋')
 })
 
@@ -21,7 +22,8 @@ test('increments and decrements counter', () => {
   expect(screen.getByTestId('count').textContent).toEqual('0')
 
   fireEvent.click(screen.getByTestId('inc'))
-  expect(screen.getByTestId('count').textContent).toEqual('1')
+  expect(screen.getByTestId('inc')).toBeEnabled()
+  expect(screen.getByTestId('count').getAttribute('disabled'))
 
   fireEvent.click(screen.getByTestId('dec'))
   expect(screen.getByTestId('count').textContent).toEqual('0')

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -24,11 +24,11 @@ test('increments and decrements counter', async () => {
   expect(screen.getByRole('status')).toBeInTheDocument()
   expect(screen.getByRole('status').textContent).toEqual('0')
 
-  expect(screen.getByText('+')).toBeEnabled()
-  await user.click(screen.getByText('+'))
+  expect(screen.getByRole('button', { name: '+' })).toBeEnabled()
+  await user.click(screen.getByRole('button', { name: '+' }))
   expect(screen.getByRole('status').getAttribute('disabled'))
 
-  expect(screen.getByText('-')).toBeEnabled()
-  await user.click(screen.getByText('-'))
+  expect(screen.getByRole('button', { name: '-' })).toBeEnabled()
+  await user.click(screen.getByRole('button', { name: '-' }))
   expect(screen.getByRole('status').textContent).toEqual('0')
 })

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup } from '@testing-library/react'
 import { expect, test, afterEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
 
 import App from './app'
 
 // Vitest API Reference: https://vitest.dev/api/
-// Testing Library Events: https://testing-library.com/docs/dom-testing-library/api-events
+// Testing Library User Events: https://testing-library.com/docs/user-event/intro/
 // Testing Library Queries: https://testing-library.com/docs/queries/about
 
 afterEach(cleanup)
@@ -12,19 +13,22 @@ afterEach(cleanup)
 test('renders app component', () => {
   render(<App />)
 
-  expect(screen.getByTestId('title')).toBeInTheDocument()
-  expect(screen.getByTestId('title').textContent).toEqual('Hello there 👋')
+  expect(screen.getByRole('heading')).toBeInTheDocument()
+  expect(screen.getByRole('heading').textContent).toEqual('Hello there 👋')
 })
 
-test('increments and decrements counter', () => {
+test('increments and decrements counter', async () => {
+  const user = userEvent.setup()
   render(<App />)
 
-  expect(screen.getByTestId('count').textContent).toEqual('0')
+  expect(screen.getByRole('status')).toBeInTheDocument()
+  expect(screen.getByRole('status').textContent).toEqual('0')
 
-  fireEvent.click(screen.getByTestId('inc'))
-  expect(screen.getByTestId('inc')).toBeEnabled()
-  expect(screen.getByTestId('count').getAttribute('disabled'))
+  expect(screen.getByText('+')).toBeEnabled()
+  await user.click(screen.getByText('+'))
+  expect(screen.getByRole('status').getAttribute('disabled'))
 
-  fireEvent.click(screen.getByTestId('dec'))
-  expect(screen.getByTestId('count').textContent).toEqual('0')
+  expect(screen.getByText('-')).toBeEnabled()
+  await user.click(screen.getByText('-'))
+  expect(screen.getByRole('status').textContent).toEqual('0')
 })

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -24,13 +24,13 @@ function App() {
 
   return (
     <Container>
-      <h2 data-testid="title">Hello there 👋</h2>
-      <h2 data-testid="count">{count}</h2>
+      <h2 role="heading">Hello there 👋</h2>
+      <h2 role="status">{count}</h2>
       <Actions>
-        <button data-testid="inc" onClick={() => setCount((prev) => prev + 1)}>
+        <button type="button" onClick={() => setCount((prev) => prev + 1)}>
           +
         </button>
-        <button data-testid="dec" onClick={() => setCount((prev) => prev - 1)}>
+        <button type="button" onClick={() => setCount((prev) => prev - 1)}>
           -
         </button>
       </Actions>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "@testing-library/jest-dom/vitest"],
     "module": "ESNext",
     "skipLibCheck": true,
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
+    setupFiles: ['./setup-tests.ts'],
   }
 })


### PR DESCRIPTION
- Add `@testing-library/jest-dom/vitest` to allow usage of `.toBeInTheDocument()` and `.isEnabled()` utilities amongst other.
- Add simpler selectors with test identifiers.